### PR TITLE
Enable Option key as Meta key in Terminal

### DIFF
--- a/packages/ui/src/components/Terminal.tsx
+++ b/packages/ui/src/components/Terminal.tsx
@@ -154,7 +154,8 @@ export const Terminal: React.FC<TerminalProps> = ({
       scrollback,
       tabStopWidth,
       windowsMode: false,
-      allowProposedApi: true
+      allowProposedApi: true,
+      macOptionIsMeta: true
     });
 
     // Load addons for enhanced functionality


### PR DESCRIPTION
## Summary
- Configured xterm.js to treat the Option key as Meta key on macOS
- Added `macOptionIsMeta: true` to terminal configuration

## Test plan
- [ ] Open the terminal in the application
- [ ] Use Option+key combinations (e.g., Option+B for backward word, Option+F for forward word)
- [ ] Verify Meta key combinations work in terminal applications like emacs or vim
- [ ] Test that regular Option key behavior still works in non-terminal parts of the app

🤖 Generated with [Claude Code](https://claude.ai/code)