### PR TITLE
fix: update xterm.js to latest GitHub version for vim support

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -65,7 +65,7 @@
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-unicode11": "^0.8.0",
     "@xterm/addon-web-links": "^0.11.0",
-    "@xterm/xterm": "^5.5.0",
+    "@xterm/xterm": "github:xtermjs/xterm.js",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.309.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,14 +11,13 @@ import { Sun, Moon, Plus, X, Terminal, GitBranch, CheckCircle } from 'lucide-rea
 import { autoLoadProjects } from './services/projectValidation';
 
 function App() {
-  const { projects, activeProjectId, addProject, addProjects, removeProject, setActiveProject, getActiveProject, setSelectedTab, theme, setTheme, connected } = useAppStore();
+  const { projects, activeProjectId, addProject, addProjects, removeProject, setActiveProject, setSelectedTab, theme, setTheme, connected } = useAppStore();
   const { connect } = useWebSocket();
   const [showProjectSelector, setShowProjectSelector] = useState(false);
   const [autoLoadAttempted, setAutoLoadAttempted] = useState(false);
   const [showSuccessNotification, setShowSuccessNotification] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   
-  const activeProject = getActiveProject();
 
   useEffect(() => {
     // Auto-connect on mount

--- a/apps/web/src/components/GitDiffView.tsx
+++ b/apps/web/src/components/GitDiffView.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
-import { ChevronLeft, RefreshCw, FileText } from 'lucide-react';
+import { RefreshCw, FileText } from 'lucide-react';
 import { DiffView, DiffModeEnum } from '@git-diff-view/react';
 import '@git-diff-view/react/styles/diff-view.css';
-import { useAppStore } from '../store';
 import { useWebSocket } from '../hooks/useWebSocket';
 import type { GitStatus } from '@vibetree/core';
 

--- a/apps/web/src/components/TerminalManager.tsx
+++ b/apps/web/src/components/TerminalManager.tsx
@@ -6,8 +6,6 @@ interface TerminalManagerProps {
   selectedWorktree: string | null;
 }
 
-// Component cache to maintain terminal instances
-const terminalComponents = new Map<string, React.ComponentType>();
 
 export function TerminalManager({ worktrees, selectedWorktree }: TerminalManagerProps) {
   const [mountedTerminals, setMountedTerminals] = useState<Set<string>>(new Set());

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/globals.css';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,7 @@
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-unicode11": "^0.8.0",
     "@xterm/addon-web-links": "^0.11.0",
-    "@xterm/xterm": "^5.5.0",
+    "@xterm/xterm": "github:xtermjs/xterm.js",
     "clsx": "^2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/xterm':
-        specifier: ^5.5.0
-        version: 5.5.0
+        specifier: github:xtermjs/xterm.js
+        version: github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -309,8 +309,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/xterm':
-        specifier: ^5.5.0
-        version: 5.5.0
+        specifier: github:xtermjs/xterm.js
+        version: github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -3488,7 +3488,7 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^5.0.0
     dependencies:
-      '@xterm/xterm': 5.5.0
+      '@xterm/xterm': github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
     dev: false
 
   /@xterm/addon-serialize@0.13.0(@xterm/xterm@5.5.0):
@@ -3496,7 +3496,7 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^5.0.0
     dependencies:
-      '@xterm/xterm': 5.5.0
+      '@xterm/xterm': github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
     dev: false
 
   /@xterm/addon-unicode11@0.8.0(@xterm/xterm@5.5.0):
@@ -3504,7 +3504,7 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^5.0.0
     dependencies:
-      '@xterm/xterm': 5.5.0
+      '@xterm/xterm': github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
     dev: false
 
   /@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0):
@@ -3512,11 +3512,7 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^5.0.0
     dependencies:
-      '@xterm/xterm': 5.5.0
-    dev: false
-
-  /@xterm/xterm@5.5.0:
-    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+      '@xterm/xterm': github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b
     dev: false
 
   /abbrev@1.1.1:
@@ -9423,4 +9419,10 @@ packages:
       '@types/react': 18.3.24
       react: 18.3.1
       use-sync-external-store: 1.5.0(react@18.3.1)
+    dev: false
+
+  github.com/xtermjs/xterm.js/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b:
+    resolution: {tarball: https://codeload.github.com/xtermjs/xterm.js/tar.gz/0d1e6b7a5e6053ab2073f77ebb2b2d80349d565b}
+    name: '@xterm/xterm'
+    version: 5.5.0
     dev: false


### PR DESCRIPTION
## Summary
- Updated @xterm/xterm to use GitHub repository directly (github:xtermjs/xterm.js)
- Fixed TypeScript unused variable warnings in web app
- This should resolve vim output handling issues by using the latest xterm.js code

## Test plan
- [ ] Test vim works correctly in the terminal
- [ ] Verify terminal rendering is working properly
- [ ] Check that all builds pass

🤖 Generated with [Claude Code](https://claude.ai/code)