### PR TITLE
feat: add bell sound support to terminal

### DIFF
--- a/packages/ui/src/components/Terminal.tsx
+++ b/packages/ui/src/components/Terminal.tsx
@@ -243,6 +243,17 @@ export const Terminal: React.FC<TerminalProps> = ({
       }
     });
 
+    // Handle bell character - play sound when bell is triggered
+    const bellDisposable = term.onBell(() => {
+      // Create an audio element and play the bell sound
+      const audio = new Audio('data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2/LDciUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhCSuBzvLZijYIG2m98OGiUSATVqzn77FgGwc4k9n1znksBSh+zPLaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSN3yfDTgDAJInfN9NuLOgoUYrfp56ZSFApGn+DyvmwhCSuBzvLZijYIG2m98OGiUSATVqzn77FgGwc4k9n1znksBSh+zPLaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQU2ktXwy3YqBSh+zPDaizsIGWi58OKjTQ8NTqbi78BkHQ==');
+      audio.volume = 0.5; // Set volume to 50%
+      audio.play().catch(err => {
+        // Silently fail if audio playback is blocked
+        console.debug('Bell sound playback failed:', err);
+      });
+    });
+
     // Cleanup on unmount
     return () => {
       window.removeEventListener('resize', handleResize);
@@ -250,6 +261,7 @@ export const Terminal: React.FC<TerminalProps> = ({
         resizeObserver.disconnect();
       }
       dataDisposable.dispose();
+      bellDisposable.dispose();
       term.dispose();
     };
   }, []);


### PR DESCRIPTION
## Summary
- Implemented audio playback when bell character (`\x07`) is received in terminal
- Terminal now plays a sound when programs output the bell character or when Ctrl+G is pressed

## Changes
- Added `onBell` event handler to Terminal component that plays an embedded WAV bell sound
- Sound plays at 50% volume to avoid being too loud
- Properly handles cases where audio playback might be blocked by browser policies
- Added cleanup to dispose bell event listener when component unmounts

## Test plan
1. Run the development server: `pnpm dev:all`
2. Open the web app at http://localhost:3305
3. In the terminal, run: `node -e "process.stdout.write('\x07')"`
4. You should hear a bell sound
5. Alternative test: Press Ctrl+G in the terminal to trigger the bell

🤖 Generated with [Claude Code](https://claude.ai/code)