### PR TITLE
test: Reduce noise in E2E test git setup

### DIFF
--- a/apps/desktop/e2e/terminal-arithmetic.spec.ts
+++ b/apps/desktop/e2e/terminal-arithmetic.spec.ts
@@ -17,14 +17,14 @@ test.describe('Terminal Arithmetic Test', () => {
 
     // Create the directory and initialize git repo
     fs.mkdirSync(dummyRepoPath, { recursive: true });
-    execSync('git init', { cwd: dummyRepoPath });
+    execSync('git init -q', { cwd: dummyRepoPath });
     execSync('git config user.email "test@example.com"', { cwd: dummyRepoPath });
     execSync('git config user.name "Test User"', { cwd: dummyRepoPath });
 
-    // Create a dummy file and make initial commit
+    // Create a dummy file and make initial commit (required for branches/worktrees)
     fs.writeFileSync(path.join(dummyRepoPath, 'README.md'), '# Test Repository\n');
     execSync('git add .', { cwd: dummyRepoPath });
-    execSync('git commit -m "Initial commit"', { cwd: dummyRepoPath });
+    execSync('git commit -q -m "Initial commit"', { cwd: dummyRepoPath });
 
     // Create main branch (some git versions don't create it by default)
     try {

--- a/apps/desktop/e2e/worktree-switch-double-char-bug.spec.ts
+++ b/apps/desktop/e2e/worktree-switch-double-char-bug.spec.ts
@@ -19,14 +19,14 @@ test.describe('Worktree Switch Double Character Bug', () => {
     
     // Create the directory and initialize git repo
     fs.mkdirSync(dummyRepoPath, { recursive: true });
-    execSync('git init', { cwd: dummyRepoPath });
+    execSync('git init -q', { cwd: dummyRepoPath });
     execSync('git config user.email "test@example.com"', { cwd: dummyRepoPath });
     execSync('git config user.name "Test User"', { cwd: dummyRepoPath });
     
-    // Create a dummy file and make initial commit
+    // Create a dummy file and make initial commit (required for worktrees)
     fs.writeFileSync(path.join(dummyRepoPath, 'README.md'), '# Test Repository\n');
     execSync('git add .', { cwd: dummyRepoPath });
-    execSync('git commit -m "Initial commit"', { cwd: dummyRepoPath });
+    execSync('git commit -q -m "Initial commit"', { cwd: dummyRepoPath });
     
     // Create worktree directories
     wt1Path = path.join(os.tmpdir(), `dummy-repo-wt1-${timestamp}`);


### PR DESCRIPTION
## Summary
- Add `-q` (quiet) flag to `git init` and `git commit` commands in E2E test setup
- Reduces unnecessary output during test execution while maintaining required initial commit for branches/worktrees

## Test plan
- [x] Run E2E tests to ensure they still pass
- [x] Verify git operations work correctly with quiet flags
- [x] Confirm worktree creation still functions properly

🤖 Generated with [Claude Code](https://claude.ai/code)