### PR TITLE
test: Enable skipped terminal sibling preservation test

### DIFF
--- a/apps/desktop/e2e/terminal-recursive-split.spec.ts
+++ b/apps/desktop/e2e/terminal-recursive-split.spec.ts
@@ -215,7 +215,7 @@ test.describe('Terminal Recursive Split Feature Test', () => {
     expect(remainingCloseButtons).toBe(0); // No close buttons should be visible when only 1 terminal remains
   });
 
-  test.skip('should preserve sibling terminals when closing a middle terminal', async () => {
+  test('should preserve sibling terminals when closing a middle terminal', async () => {
     test.setTimeout(90000);
 
     await page.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
## Summary
- Unskipped the test case "should preserve sibling terminals when closing a middle terminal"
- This test verifies that when closing a middle terminal in a recursive split setup, the sibling terminals are preserved correctly

## Test Plan
- [x] Unskipped the test in `e2e/terminal-recursive-split.spec.ts`
- [ ] Run the e2e tests locally to verify (Note: Tests are currently failing due to Electron launch issues in the test environment)

🤖 Generated with [Claude Code](https://claude.ai/code)