### PR TITLE
ci: Add 5-minute timeout to Playwright installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         npx tsc src/main/test-index.ts --outDir dist/main --target es2020 --module commonjs --esModuleInterop --allowSyntheticDefaultImports --resolveJsonModule
 
     - name: Install Playwright browsers and dependencies
+      timeout-minutes: 5
       run: |
         pnpm --filter @vibetree/desktop exec playwright install
         pnpm --filter @vibetree/desktop exec playwright install-deps


### PR DESCRIPTION
## Summary
- Added a 5-minute timeout to the "Install Playwright browsers and dependencies" step in the CI workflow
- This prevents the CI from hanging indefinitely if the Playwright installation encounters issues

## Test plan
- [ ] CI workflow runs successfully with the timeout in place
- [ ] If Playwright installation takes longer than 5 minutes, the step fails gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)