### PR TITLE
Do not open DevTools automatically in development mode

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -42,8 +42,7 @@ function createWindow() {
       console.warn('Could not read dev port file, using default port 3000');
     }
     mainWindow.loadURL(`http://localhost:${port}`);
-    // Open DevTools in development
-    mainWindow.webContents.openDevTools();
+    // DevTools can be opened manually via Toggle Developer Tools
   } else {
     mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
   }


### PR DESCRIPTION
## Summary
- Removed automatic opening of DevTools when the Electron app starts in development mode
- DevTools can still be opened manually via the Toggle Developer Tools menu option

## Test plan
- [ ] Start the app in development mode
- [ ] Verify DevTools do not open automatically
- [ ] Verify DevTools can still be opened via menu (View > Toggle Developer Tools)

🤖 Generated with [Claude Code](https://claude.ai/code)