### PR TITLE
feat: Disable inactive session cleanup to keep sessions alive for Claude feedback

### DIFF
--- a/packages/core/src/services/ShellSessionManager.ts
+++ b/packages/core/src/services/ShellSessionManager.ts
@@ -39,8 +39,8 @@ export class ShellSessionManager {
   private cleanupInterval: NodeJS.Timeout | null = null;
 
   private constructor() {
-    // Start cleanup timer
-    this.cleanupInterval = setInterval(() => this.cleanupInactiveSessions(), 60000);
+    // Cleanup timer disabled - keep sessions alive for Claude feedback
+    // this.cleanupInterval = setInterval(() => this.cleanupInactiveSessions(), 60000);
   }
 
   /**


### PR DESCRIPTION
## Summary
• Disabled automatic cleanup of inactive shell sessions
• Sessions now remain active indefinitely to provide continuous feedback for Claude reports
• Modified `ShellSessionManager` to comment out the cleanup timer initialization

## Test plan
- [x] Build passes successfully
- [x] Linting passes with no new errors
- [x] Sessions will no longer be terminated after 30 minutes of inactivity
- [x] Existing session functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)