### PR TITLE
feat: Replace terminal sharing with hide/show mechanism

### DIFF
--- a/apps/desktop/e2e/worktree-switch-double-char-bug.spec.ts
+++ b/apps/desktop/e2e/worktree-switch-double-char-bug.spec.ts
@@ -175,8 +175,8 @@ test.describe('Worktree Switch Double Character Bug', () => {
     await page.keyboard.type('echo');
     await page.waitForTimeout(1000);
 
-    // Get the terminal content
-    const terminalContent = await page.locator('.xterm-screen').textContent();
+    // Get the terminal content from the visible terminal
+    const terminalContent = await page.locator('.xterm-screen:visible').first().textContent();
     console.log('Terminal content after typing "echo":', terminalContent);
 
     // The bug causes "eecchhoo" to appear instead of "echo"

--- a/apps/desktop/e2e/worktree-terminal-content-preservation.spec.ts
+++ b/apps/desktop/e2e/worktree-terminal-content-preservation.spec.ts
@@ -159,15 +159,24 @@ test.describe('Worktree Terminal Content Preservation', () => {
     console.log('Waiting 3 seconds for worktree to load...');
     await page.waitForTimeout(3000);
 
-    // Verify we have a terminal in wt1
+    // Verify we have terminals in wt1 (one visible, one hidden)
     console.log('\n--- Checking terminal in wt1 ---');
     terminalContainers = page.locator('.xterm-screen');
     terminalCount = await terminalContainers.count();
     console.log(`Terminal count in wt1: ${terminalCount}`);
-    expect(terminalCount).toBe(1);
+    
+    // With the new TerminalManager, we expect 2 terminals (main hidden, wt1 visible)
+    expect(terminalCount).toBe(2);
+    
+    // Verify exactly one terminal is visible
+    const visibleTerminals = page.locator('.xterm-screen:visible');
+    const visibleCount = await visibleTerminals.count();
+    expect(visibleCount).toBe(1);
+    console.log(`Visible terminal count in wt1: ${visibleCount}`);
     
     // Type something in wt1 terminal to make it distinct
-    const wt1Terminal = terminalContainers.first();
+    // Find the visible terminal
+    const wt1Terminal = page.locator('.xterm-screen:visible').first();
     await wt1Terminal.click();
     await page.waitForTimeout(500);
     await page.keyboard.type('echo "This is wt1"');
@@ -192,9 +201,17 @@ test.describe('Worktree Terminal Content Preservation', () => {
     terminalContainers = page.locator('.xterm-screen');
     terminalCount = await terminalContainers.count();
     console.log(`Terminal count in main (after switch back): ${terminalCount}`);
-    expect(terminalCount).toBe(1);
     
-    const mainTerminalAfter = terminalContainers.first();
+    // We should still have 2 terminals (main visible, wt1 hidden)
+    expect(terminalCount).toBe(2);
+    
+    // Verify exactly one terminal is visible
+    const visibleTerminalsAfter = page.locator('.xterm-screen:visible');
+    const visibleCountAfter = await visibleTerminalsAfter.count();
+    expect(visibleCountAfter).toBe(1);
+    console.log(`Visible terminal count in main (after switch back): ${visibleCountAfter}`);
+    
+    const mainTerminalAfter = page.locator('.xterm-screen:visible').first();
     const mainTerminalContentAfter = await mainTerminalAfter.textContent();
     console.log(`Main terminal content after switching back: ${mainTerminalContentAfter?.substring(0, 200)}...`);
     

--- a/apps/desktop/src/renderer/components/RightPaneView.tsx
+++ b/apps/desktop/src/renderer/components/RightPaneView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './ui/tabs';
-import { ClaudeTerminal } from './ClaudeTerminal';
+import { TerminalManager } from './TerminalManager';
 import { GitDiffView } from './GitDiffView';
 import { Terminal, GitBranch } from 'lucide-react';
 
@@ -43,7 +43,7 @@ export function RightPaneView({ worktreePath, projectId, theme }: RightPaneViewP
           value="terminal"
           className="flex-1 m-0 h-full"
         >
-          <ClaudeTerminal 
+          <TerminalManager 
             worktreePath={worktreePath} 
             projectId={projectId}
             theme={theme}

--- a/apps/desktop/src/renderer/components/TerminalManager.tsx
+++ b/apps/desktop/src/renderer/components/TerminalManager.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react';
+import { ClaudeTerminal } from './ClaudeTerminal';
+
+interface TerminalManagerProps {
+  worktreePath: string;
+  projectId?: string;
+  theme?: 'light' | 'dark';
+}
+
+interface TerminalInstance {
+  worktreePath: string;
+  isVisible: boolean;
+}
+
+export function TerminalManager({ worktreePath, projectId, theme }: TerminalManagerProps) {
+  const [terminals, setTerminals] = useState<Map<string, TerminalInstance>>(new Map());
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTerminals(prevTerminals => {
+      const newTerminals = new Map(prevTerminals);
+      
+      // Hide all existing terminals
+      for (const [path, terminal] of newTerminals) {
+        if (terminal.isVisible) {
+          newTerminals.set(path, {
+            ...terminal,
+            isVisible: false
+          });
+        }
+      }
+      
+      // Show or create terminal for current worktree
+      if (!newTerminals.has(worktreePath)) {
+        // Create new terminal instance
+        newTerminals.set(worktreePath, {
+          worktreePath,
+          isVisible: true
+        });
+      } else {
+        // Show existing terminal
+        const existingTerminal = newTerminals.get(worktreePath)!;
+        newTerminals.set(worktreePath, {
+          ...existingTerminal,
+          isVisible: true
+        });
+      }
+      
+      return newTerminals;
+    });
+  }, [worktreePath, projectId, theme]);
+
+
+  return (
+    <div ref={containerRef} className="flex-1 h-full relative">
+      {Array.from(terminals.values()).map((terminal) => (
+        <div
+          key={terminal.worktreePath}
+          className="absolute inset-0 w-full h-full"
+          style={{
+            display: terminal.isVisible ? 'block' : 'none'
+          }}
+        >
+          <ClaudeTerminal
+            key={terminal.worktreePath}
+            worktreePath={terminal.worktreePath}
+            projectId={projectId}
+            theme={theme}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace terminal sharing between worktrees with individual terminal instances
- Implement hide/show mechanism instead of terminal recreation when switching worktrees  
- Each worktree maintains its own persistent terminal session

## Key Changes
- **New TerminalManager component** manages multiple terminal instances per project
- **CSS-based visibility control** hides inactive terminals, shows active worktree terminal
- **Persistent terminal sessions** eliminate flickering and improve content preservation
- **Updated E2E tests** to work with new 2-terminal architecture

## Test Plan
- [x] Build passes successfully
- [x] E2E test `worktree-terminal-content-preservation.spec.ts` passes
- [x] E2E test `worktree-switch-double-char-bug.spec.ts` updated and passes
- [x] Verified terminal content preservation when switching between worktrees
- [x] Confirmed no cross-contamination between worktree terminal sessions

## Technical Details
Previously, switching worktrees would destroy and recreate terminal components, causing flickering and potential content loss. Now each worktree gets its own persistent `ClaudeTerminal` instance that's hidden/shown via `display: none/block` CSS styling.

This approach maintains separate node-pty sessions per worktree while providing smooth transitions and reliable content preservation.

🤖 Generated with [Claude Code](https://claude.ai/code)