### PR TITLE
feat: Persistent TerminalGrid instances per worktree

### DIFF
--- a/.claude/agents/electron-app-debugger.md
+++ b/.claude/agents/electron-app-debugger.md
@@ -1,0 +1,71 @@
+---
+name: electron-app-debugger
+description: Use this agent when you need to debug Electron application issues, particularly UI-related problems, component rendering issues, or when you need to bypass native dialogs for testing. This agent specializes in visual debugging through screenshots and color manipulation, and can programmatically control the app for testing purposes.\n\nExamples:\n- <example>\n  Context: User is experiencing UI rendering issues in their Electron app\n  user: "The sidebar menu isn't showing up correctly in dark mode"\n  assistant: "I'll use the electron-app-debugger agent to diagnose this UI issue by taking screenshots and manipulating component colors"\n  <commentary>\n  Since this is a UI rendering issue in an Electron app, the electron-app-debugger agent should be used to visually debug the problem.\n  </commentary>\n</example>\n- <example>\n  Context: User needs to test file opening functionality without manual interaction\n  user: "I need to test the project import feature but the native file dialog keeps blocking automated tests"\n  assistant: "Let me launch the electron-app-debugger agent to bypass the native file dialog and test the project opening directly"\n  <commentary>\n  The user needs to bypass native dialogs for testing, which is a specific capability of the electron-app-debugger agent.\n  </commentary>\n</example>\n- <example>\n  Context: User wants to verify component visibility and styling\n  user: "Can you check if all the buttons are visible and have the correct colors after the theme switch?"\n  assistant: "I'll use the electron-app-debugger agent to change component colors and capture screenshots for visual verification"\n  <commentary>\n  Visual verification through color manipulation and screenshots is a core capability of this debugging agent.\n  </commentary>\n</example>
+model: inherit
+---
+
+You are an expert Electron application debugger with deep knowledge of Electron's architecture, Chromium DevTools, and UI debugging techniques. You specialize in diagnosing and resolving issues in Electron applications through visual debugging, component manipulation, and automated testing approaches.
+
+**Core Capabilities:**
+
+1. **Electron Expertise**: You have comprehensive knowledge of Electron's main and renderer processes, IPC communication, BrowserWindow APIs, and the integration between Node.js and Chromium.
+
+2. **Project-Specific Knowledge**: You must consult and follow the debugging procedures outlined in docs/electron-debug.md for this specific application. Always reference this documentation for app-specific debugging patterns and known issues.
+
+3. **Native Dialog Bypass**: You can programmatically trigger project opening and other file operations without relying on native file dialogs, using Electron's APIs to directly pass file paths and bypass user interaction requirements.
+
+4. **Visual Debugging**: You excel at:
+   - Taking screenshots of the application at various states using Electron's screenshot APIs
+   - Manipulating component colors through DevTools protocol or CSS injection to highlight rendering issues
+   - Creating before/after comparisons to diagnose UI problems
+   - Capturing screenshots of specific BrowserWindow regions or components
+
+5. **Component Manipulation**: You can:
+   - Inject CSS to change colors of specific components for visibility testing
+   - Use JavaScript execution in the renderer process to modify DOM elements
+   - Apply temporary style overrides to isolate rendering issues
+   - Toggle component states programmatically for testing
+
+**Debugging Workflow:**
+
+1. **Initial Assessment**: When presented with an issue, first check docs/electron-debug.md for any documented solutions or known issues related to the problem.
+
+2. **Environment Setup**: Ensure the Electron app is running in debug mode with appropriate DevTools access and remote debugging enabled if needed.
+
+3. **Systematic Diagnosis**:
+   - Take initial screenshots to document the current state
+   - Apply color changes to suspected problematic components (use contrasting colors like red, blue, or green borders/backgrounds)
+   - Take comparison screenshots after modifications
+   - Document which components are rendering correctly vs incorrectly
+
+4. **Bypass Strategies**: When encountering native dialogs:
+   - Use `dialog.showOpenDialog` with mock return values
+   - Directly invoke file handling functions with hardcoded paths
+   - Implement `protocol.interceptFileProtocol` for testing file operations
+   - Use `webContents.executeJavaScript` to trigger actions programmatically
+
+5. **Screenshot Methodology**:
+   - Always capture full window screenshots first for context
+   - Use `capturePage()` API for specific regions when needed
+   - Save screenshots with descriptive names including timestamp and issue context
+   - Create side-by-side comparisons when demonstrating issues
+
+**Best Practices:**
+
+- Always create a debugging session log documenting each step taken
+- Preserve original styles before applying color changes for easy restoration
+- Use semantic color coding: red for errors, yellow for warnings, green for successful elements
+- Take screenshots at multiple zoom levels if DPI scaling might be an issue
+- Test with both development and production builds when applicable
+- Clear cache and session data when debugging persistent UI issues
+
+**Output Format:**
+
+When debugging, provide:
+1. A clear diagnosis of the issue with screenshot evidence
+2. Step-by-step reproduction steps if applicable
+3. The specific component or code section causing the problem
+4. Recommended fixes with code examples
+5. Prevention strategies for similar issues
+
+You should be proactive in suggesting additional debugging steps if initial approaches don't reveal the issue. Always consider both the main process and renderer process when diagnosing problems, and check for console errors, network issues, and timing problems that might affect UI rendering.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "predev": "cd ../../packages/core && pnpm build",
     "dev": "concurrently \"pnpm dev:main\" \"pnpm dev:preload\" \"pnpm dev:renderer\" \"pnpm dev:electron\"",
-    "dev:debug": "concurrently \"pnpm dev:main\" \"pnpm dev:preload\" \"pnpm dev:renderer\" \"pnpm dev:electron:debug\"",
+    "dev:debug": "DEBUG_LAYOUT=true concurrently \"pnpm dev:main\" \"pnpm dev:preload\" \"DEBUG_LAYOUT=true pnpm dev:renderer\" \"pnpm dev:electron:debug\"",
     "dev:main": "tsc -w -p tsconfig.main.json",
     "dev:preload": "tsc -w -p tsconfig.preload.json",
     "dev:renderer": "vite",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "predev": "cd ../../packages/core && pnpm build",
     "dev": "concurrently \"pnpm dev:main\" \"pnpm dev:preload\" \"pnpm dev:renderer\" \"pnpm dev:electron\"",
+    "dev:debug": "concurrently \"pnpm dev:main\" \"pnpm dev:preload\" \"pnpm dev:renderer\" \"pnpm dev:electron:debug\"",
     "dev:main": "tsc -w -p tsconfig.main.json",
     "dev:preload": "tsc -w -p tsconfig.preload.json",
     "dev:renderer": "vite",
     "dev:electron": "node wait-for-dev-server.js && wait-on dist/main/index.js && wait-on dist/preload/index.js && electron .",
+    "dev:electron:debug": "node wait-for-dev-server.js && wait-on dist/main/index.js && wait-on dist/preload/index.js && electron . --remote-debugging-port=9222",
     "prebuild": "cd ../../packages/core && pnpm build",
     "build": "pnpm build:main && pnpm build:preload && pnpm build:renderer",
     "build:main": "tsc -p tsconfig.main.json",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -94,6 +94,7 @@
     "node-pty": "^1.1.0-beta34",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-reverse-portal": "^2.3.0",
     "tailwind-merge": "^2.2.0"
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -241,6 +241,15 @@ ipcMain.handle('dialog:select-directory', async () => {
   return result.filePaths[0];
 });
 
+// Programmatic project opening (for testing)
+ipcMain.handle('project:open-path', async (_, projectPath: string) => {
+  if (mainWindow && fs.existsSync(projectPath)) {
+    mainWindow.webContents.send('project:open', projectPath);
+    return { success: true };
+  }
+  return { success: false, error: 'Invalid path or window not ready' };
+});
+
 // Open external links
 ipcMain.handle('shell:open-external', async (_, url: string) => {
   await shell.openExternal(url);

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -28,6 +28,15 @@ function AppContent() {
         setTheme(newTheme);
       }
     });
+
+    // Load debug CSS if DEBUG_LAYOUT environment variable is set
+    if (process.env.DEBUG_LAYOUT === 'true') {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = './styles/debug-layout.css';
+      document.head.appendChild(link);
+      console.log('🎨 Debug layout mode enabled - Component borders visible');
+    }
   }, []);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -65,7 +65,7 @@ function AppContent() {
   };
 
   return (
-    <div className="h-screen flex flex-col bg-background">
+    <div className="h-screen flex flex-col bg-background overflow-hidden">
       <AppHeader theme={theme} onThemeToggle={toggleTheme} />
 
       {projects.length === 0 || showProjectSelector ? (
@@ -74,9 +74,9 @@ function AppContent() {
         <Tabs 
           value={activeProjectId || ''} 
           onValueChange={setActiveProject}
-          className="flex-1 flex flex-col"
+          className="flex-1 flex flex-col overflow-hidden"
         >
-          <div className="border-b flex items-center gap-2 bg-muted/50 h-10">
+          <div className="border-b flex items-center gap-2 bg-muted/50 h-10 flex-shrink-0">
             <TabsList className="h-full bg-transparent p-0 rounded-none">
               {projects.map((project) => (
                 <TabsTrigger
@@ -108,7 +108,8 @@ function AppContent() {
             <TabsContent 
               key={project.id} 
               value={project.id}
-              className="flex-1 m-0 h-full"
+              className="flex-1 m-0 overflow-hidden"
+              style={{ display: activeProjectId === project.id ? 'flex' : 'none', flexDirection: 'column' }}
             >
               <ProjectWorkspace projectId={project.id} theme={theme} />
             </TabsContent>

--- a/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
+++ b/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
@@ -490,8 +490,8 @@ export function ClaudeTerminal({ worktreePath, theme = 'dark', isVisible = true 
       {/* Terminal container */}
       <div 
         ref={terminalRef} 
-        className={`flex-1 h-full ${theme === 'light' ? 'bg-white' : 'bg-black'}`}
-        style={{ minHeight: '100px' }}
+        className={`flex-1 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}
+        style={{ minHeight: '100px', height: '100%' }}
       />
     </div>
   );

--- a/apps/desktop/src/renderer/components/RightPaneView.tsx
+++ b/apps/desktop/src/renderer/components/RightPaneView.tsx
@@ -14,11 +14,11 @@ export function RightPaneView({ worktreePath, projectId, theme }: RightPaneViewP
   const [activeTab, setActiveTab] = useState('terminal');
 
   return (
-    <div className="flex-1 flex flex-col h-full">
+    <div className="flex-1 flex flex-col h-full overflow-hidden">
       <Tabs 
         value={activeTab} 
         onValueChange={setActiveTab}
-        className="flex-1 flex flex-col"
+        className="flex-1 flex flex-col overflow-hidden"
       >
         <div className="border-b flex items-center bg-muted/50 h-12">
           <TabsList className="h-full bg-transparent p-0 rounded-none ml-4">
@@ -41,7 +41,7 @@ export function RightPaneView({ worktreePath, projectId, theme }: RightPaneViewP
 
         <TabsContent 
           value="terminal"
-          className="flex-1 m-0 h-full"
+          className="flex-1 m-0 flex flex-col overflow-hidden"
         >
           <TerminalManager 
             worktreePath={worktreePath} 
@@ -52,7 +52,7 @@ export function RightPaneView({ worktreePath, projectId, theme }: RightPaneViewP
 
         <TabsContent 
           value="git-diff"
-          className="flex-1 m-0 h-full"
+          className="flex-1 m-0 flex flex-col overflow-hidden"
         >
           <GitDiffView worktreePath={worktreePath} theme={theme} />
         </TabsContent>

--- a/apps/desktop/src/renderer/components/TerminalManager.tsx
+++ b/apps/desktop/src/renderer/components/TerminalManager.tsx
@@ -42,36 +42,35 @@ export function TerminalManager({ worktreePath, projectId, theme }: TerminalMana
 
   // Get all terminal portals that have been created
   const allPortals = useMemo(() => Array.from(terminalPortals.values()), [terminalPortals]);
+  
+  // Get the current portal
+  const currentPortal = useMemo(() => 
+    allPortals.find(p => p.worktreePath === worktreePath), 
+    [allPortals, worktreePath]
+  );
 
   return (
-    <div ref={containerRef} className="flex-1 h-full relative">
-      {/* Render all terminals into their portals (this happens once per terminal) */}
-      {allPortals.map((portal) => (
-        <InPortal key={portal.worktreePath} node={portal.portalNode}>
-          <ClaudeTerminal
-            worktreePath={portal.worktreePath}
-            projectId={projectId}
-            theme={theme}
-            isVisible={portal.worktreePath === worktreePath}
-          />
-        </InPortal>
-      ))}
+    <>
+      {/* Hidden container for InPortal elements - outside of the visible area */}
+      <div style={{ display: 'none' }}>
+        {allPortals.map((portal) => (
+          <InPortal key={portal.worktreePath} node={portal.portalNode}>
+            <ClaudeTerminal
+              worktreePath={portal.worktreePath}
+              projectId={projectId}
+              theme={theme}
+              isVisible={portal.worktreePath === worktreePath}
+            />
+          </InPortal>
+        ))}
+      </div>
       
-      {/* Show only the current worktree's terminal via OutPortal */}
-      {allPortals.map((portal) => (
-        <div
-          key={`out-${portal.worktreePath}`}
-          className="absolute inset-0 w-full h-full"
-          style={{
-            display: portal.worktreePath === worktreePath ? 'block' : 'none',
-            visibility: portal.worktreePath === worktreePath ? 'visible' : 'hidden'
-          }}
-        >
-          {portal.worktreePath === worktreePath && (
-            <OutPortal node={portal.portalNode} />
-          )}
-        </div>
-      ))}
-    </div>
+      {/* Visible container for the current terminal */}
+      <div ref={containerRef} className="flex-1 h-full flex flex-col">
+        {currentPortal && (
+          <OutPortal node={currentPortal.portalNode} />
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/desktop/src/renderer/styles/debug-layout.css
+++ b/apps/desktop/src/renderer/styles/debug-layout.css
@@ -1,0 +1,171 @@
+/* Debug styles for terminal layout visualization */
+/* This file is only loaded when running with DEBUG_LAYOUT=true */
+
+/* ProjectWorkspace - main container with tabs content */
+[role="tabpanel"] > div.flex-1.flex.h-full {
+  border: 3px solid pink !important;
+  background-color: rgba(255, 192, 203, 0.1) !important;
+  position: relative;
+}
+
+[role="tabpanel"] > div.flex-1.flex.h-full::before {
+  content: 'ProjectWorkspace';
+  position: absolute;
+  top: 40px;
+  left: 0;
+  background: deeppink;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* WorktreePanel - left sidebar */
+[role="tabpanel"] > div > div.w-80.border-r {
+  border: 3px solid brown !important;
+  background-color: rgba(165, 42, 42, 0.05) !important;
+  position: relative;
+}
+
+[role="tabpanel"] > div > div.w-80.border-r::before {
+  content: 'WorktreePanel';
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: brown;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* RightPaneView - contains terminal/git tabs */
+[role="tabpanel"] > div > div:last-child.flex-1.flex.flex-col {
+  border: 3px solid orange !important;
+  background-color: rgba(255, 165, 0, 0.05) !important;
+  position: relative;
+}
+
+[role="tabpanel"] > div > div:last-child.flex-1.flex.flex-col::before {
+  content: 'RightPaneView';
+  position: absolute;
+  top: 0;
+  right: 100px;
+  background: orange;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* TerminalManager - container for terminal instances */
+[role="tabpanel"] div.relative.flex-1.h-full:has(> div.absolute.inset-0) {
+  border: 3px solid red !important;
+  background-color: rgba(255, 0, 0, 0.05) !important;
+  position: relative;
+}
+
+[role="tabpanel"] div.relative.flex-1.h-full:has(> div.absolute.inset-0)::before {
+  content: 'TerminalManager';
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: red;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* Terminal Container - individual terminal wrapper */
+div.absolute.inset-0.w-full.h-full {
+  border: 3px solid blue !important;
+  background-color: rgba(0, 0, 255, 0.05) !important;
+  position: relative;
+}
+
+div.absolute.inset-0.w-full.h-full::before {
+  content: 'Terminal Container';
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: blue;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* Terminal Header - the header with title and buttons */
+div.h-\[57px\].px-4.border-b.flex.items-center.justify-between {
+  border: 2px solid green !important;
+  background-color: rgba(0, 255, 0, 0.1) !important;
+  position: relative;
+}
+
+div.h-\[57px\].px-4.border-b.flex.items-center.justify-between::before {
+  content: 'Terminal Header';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: green;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* XTerm terminal instance - the actual terminal div */
+.xterm {
+  border: 3px solid purple !important;
+  background-color: rgba(128, 0, 128, 0.05) !important;
+  position: relative;
+}
+
+.xterm::before {
+  content: 'XTerm Instance';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: purple;
+  color: white;
+  padding: 2px 8px;
+  font-size: 12px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* Terminal content area where xterm renders */
+div.flex-1.h-full:has(.xterm) {
+  border: 3px solid cyan !important;
+  background-color: rgba(0, 255, 255, 0.05) !important;
+}
+
+/* Tab content areas */
+[role="tabpanel"][data-state="active"] {
+  outline: 2px dashed yellow !important;
+  outline-offset: -2px;
+}
+
+/* Additional debug info in console */
+body::before {
+  content: '⚠️ DEBUG LAYOUT MODE ACTIVE';
+  position: fixed;
+  top: 5px;
+  right: 5px;
+  background: red;
+  color: white;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: bold;
+  z-index: 10000;
+  pointer-events: none;
+  border-radius: 3px;
+}

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -58,3 +58,11 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   }
 }
+
+/* Ensure portal content fills container */
+.terminal-portal-container > * {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -43,4 +43,7 @@ export default defineConfig({
     port: Math.floor(Math.random() * 1000) + 3000,
     strictPort: false, // Allow Vite to find alternative ports if the random port is taken
   },
+  define: {
+    'process.env.DEBUG_LAYOUT': JSON.stringify(process.env.DEBUG_LAYOUT || 'false'),
+  },
 });

--- a/docs/electron-debug.md
+++ b/docs/electron-debug.md
@@ -18,6 +18,49 @@ pnpm dev:debug
 
 This command is configured in `package.json` to start Electron with `--remote-debugging-port=9222`.
 
+## Layout Debugging Mode
+
+The application includes a special layout debugging mode that visualizes component boundaries with colored borders. This is useful for debugging layout issues, especially with terminal components.
+
+### Enabling Layout Debug Mode
+
+Run the application with layout debugging:
+
+```bash
+# From root directory
+pnpm dev:desktop:debug
+
+# Or from desktop directory
+cd apps/desktop
+pnpm dev:debug
+```
+
+This sets `DEBUG_LAYOUT=true` environment variable and loads additional debug CSS.
+
+### What You'll See
+
+When layout debug mode is active:
+- **Red indicator** appears in top-right corner: "⚠️ DEBUG LAYOUT MODE ACTIVE"
+- Each component gets a colored border with a label:
+  - **Pink border** - ProjectWorkspace (main container)
+  - **Brown border** - WorktreePanel (left sidebar)
+  - **Orange border** - RightPaneView (terminal/git tabs container)
+  - **Red border** - TerminalManager (manages terminal instances)
+  - **Blue border** - Terminal containers (individual terminal wrappers)
+  - **Green border** - Terminal header (title and controls)
+  - **Purple border** - XTerm instance (actual terminal)
+  - **Cyan border** - Terminal content area containing XTerm
+  - **Yellow dashed outline** - Active tab panels
+
+### Modifying Debug Styles
+
+The debug styles are in a separate CSS file:
+```
+apps/desktop/src/renderer/styles/debug-layout.css
+```
+
+You can modify this file to add more debug visualizations without changing any component code. The CSS uses attribute selectors and class combinations to target components.
+
 ## Starting the Application
 
 ```bash

--- a/docs/electron-debug.md
+++ b/docs/electron-debug.md
@@ -1,0 +1,325 @@
+# Electron MCP Debugging Guide
+
+This guide documents how to debug and interact with the VibeTree Electron application using the Electron MCP (Model Context Protocol) tools.
+
+## Prerequisites
+
+1. Electron MCP server must be installed and running
+2. The Electron app must be started with remote debugging enabled
+
+## Enabling Remote Debugging
+
+Run the application with debugging enabled:
+
+```bash
+cd apps/desktop
+pnpm dev:debug
+```
+
+This command is configured in `package.json` to start Electron with `--remote-debugging-port=9222`.
+
+## Starting the Application
+
+```bash
+cd apps/desktop
+pnpm dev
+```
+
+Wait for the app to fully start (approximately 8 seconds).
+
+## Using Electron MCP Tools
+
+### 1. Check Window Information
+```javascript
+mcp__electron__get_electron_window_info({ includeChildren: true })
+```
+
+This returns information about all running Electron windows, including process IDs and debugging URLs.
+
+### 2. Take Screenshots
+```javascript
+mcp__electron__take_screenshot({ 
+  outputPath: "/tmp/screenshot.png" 
+})
+```
+
+### 3. Get Page Structure
+```javascript
+mcp__electron__send_command_to_electron({
+  command: "get_page_structure",
+  args: {}
+})
+```
+
+Returns buttons, inputs, selects, and links on the current page.
+
+### 4. Execute JavaScript
+```javascript
+mcp__electron__send_command_to_electron({
+  command: "eval",
+  args: { code: "/* your JavaScript code */" }
+})
+```
+
+### 5. Click Elements
+```javascript
+// Click by text
+mcp__electron__send_command_to_electron({
+  command: "click_by_text",
+  args: { text: "Button Text" }
+})
+
+// Click by selector
+mcp__electron__send_command_to_electron({
+  command: "click_by_selector",
+  args: { selector: ".button-class" }
+})
+```
+
+### 6. Send Keyboard Shortcuts
+```javascript
+mcp__electron__send_command_to_electron({
+  command: "send_keyboard_shortcut",
+  args: { text: "Meta+O" }  // Cmd+O on Mac
+})
+```
+
+Common shortcuts:
+- `Meta+O`: Open file/folder dialog
+- `Escape`: Close dialogs
+- `Enter`: Confirm actions
+- `Meta+N`: New window/tab (app-specific)
+
+### 7. Fill Forms
+```javascript
+mcp__electron__send_command_to_electron({
+  command: "fill_input",
+  args: { 
+    selector: "#input-id",
+    value: "text to input"
+  }
+})
+```
+
+### 8. Read Console Logs
+```javascript
+mcp__electron__read_electron_logs({
+  logType: "console",
+  lines: 20
+})
+```
+
+## Interacting with VibeTree Application
+
+### Understanding the IPC Bridge
+
+The app uses `window.electronAPI` to communicate between renderer and main process:
+
+```javascript
+window.electronAPI = {
+  git: { ... },        // Git operations
+  shell: { ... },      // Terminal operations
+  ide: { ... },        // IDE integrations
+  theme: { ... },      // Theme management
+  dialog: { ... },     // Native dialogs
+  recentProjects: { ... }  // Project management
+}
+```
+
+### Opening a Project Programmatically
+
+#### Method 1: Using Recent Projects API
+```javascript
+// Add to recent projects
+window.electronAPI.recentProjects.add('/path/to/project')
+
+// Get recent projects
+window.electronAPI.recentProjects.get()
+```
+
+#### Method 2: Triggering IPC Events
+The app listens for `project:open` and `project:open-recent` events:
+
+```javascript
+// Simulate project open event (from renderer)
+window.dispatchEvent(new CustomEvent('ipc-project:open', { 
+  detail: '/path/to/project' 
+}))
+```
+
+#### Method 3: Using Dialog API
+```javascript
+// Open native folder selector
+window.electronAPI.dialog.selectDirectory()
+```
+
+### Navigating Worktrees
+
+1. Get worktrees for a project:
+```javascript
+window.electronAPI.git.listWorktrees('/path/to/project')
+```
+
+2. Add a new worktree:
+```javascript
+window.electronAPI.git.addWorktree('/path/to/project', 'branch-name')
+```
+
+### Terminal Operations
+
+1. Start a shell session:
+```javascript
+window.electronAPI.shell.start('/path/to/worktree', 80, 24)
+```
+
+2. Write to terminal:
+```javascript
+window.electronAPI.shell.write('processId', 'command\n')
+```
+
+3. Resize terminal:
+```javascript
+window.electronAPI.shell.resize('processId', cols, rows)
+```
+
+## Simulating Terminal Input
+
+To simulate keyboard input in the terminal:
+
+```javascript
+// Method 1: Send keyboard events directly
+mcp__electron__send_command_to_electron({
+  command: "eval",
+  args: { 
+    code: `
+      // Simulate typing text
+      const text = 'echo test';
+      for (const char of text) {
+        const keyEvent = new KeyboardEvent('keydown', {
+          key: char,
+          code: 'Key' + char.toUpperCase(),
+          charCode: char.charCodeAt(0),
+          keyCode: char.charCodeAt(0),
+          which: char.charCodeAt(0),
+          bubbles: true
+        });
+        document.dispatchEvent(keyEvent);
+      }
+      'Sent: ' + text;
+    `
+  }
+});
+
+// Method 2: Send Enter key
+mcp__electron__send_command_to_electron({
+  command: "eval",
+  args: { 
+    code: `
+      const enterEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        which: 13,
+        bubbles: true
+      });
+      document.dispatchEvent(enterEvent);
+      'Enter key sent';
+    `
+  }
+});
+```
+
+Note: This simulates keyboard events at the document level. The terminal must be focused to receive the input.
+
+## Common Issues and Solutions
+
+### Issue: Native File Dialog Cannot Be Controlled
+**Problem**: Electron MCP cannot interact with native OS dialogs.
+**Solution**: Use the IPC bridge or programmatic methods to set project paths directly.
+
+### Issue: React State Not Accessible
+**Problem**: React component state is encapsulated and not directly accessible.
+**Solution**: 
+1. Use React DevTools hook: `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`
+2. Trigger actions through DOM events
+3. Use the IPC bridge to communicate with the main process
+
+### Issue: Terminal Not Taking Full Height
+**Problem**: Terminal leaves empty space at the bottom.
+**Solutions**:
+1. Check flex container settings
+2. Verify portal rendering doesn't affect layout
+3. Ensure parent containers have proper height: 100%
+4. Check for conflicting CSS styles
+
+## Useful Debug Commands
+
+### Check React Components
+```javascript
+// Find React fiber root
+const root = document.getElementById('root');
+const fiber = root._reactRootContainer?._internalRoot?.current;
+```
+
+### Monitor IPC Messages
+```javascript
+// Log all IPC events (in main process)
+ipcMain.on('*', (event, ...args) => {
+  console.log('IPC Event:', event.channel, args);
+});
+```
+
+### Inspect Terminal State
+```javascript
+// Get terminal dimensions
+const terminal = document.querySelector('.xterm');
+console.log({
+  cols: terminal.terminal.cols,
+  rows: terminal.terminal.rows,
+  height: terminal.offsetHeight
+});
+```
+
+## Tips for Effective Debugging
+
+1. **Always wait for app to fully load** before sending commands
+2. **Use screenshots** to verify UI state
+3. **Check console logs** for errors or debug messages
+4. **Use eval command** for custom JavaScript execution
+5. **Combine multiple MCP commands** for complex interactions
+6. **Monitor background processes** using BashOutput tool
+
+## Example: Complete Project Open Flow
+
+```javascript
+// 1. Check app state
+await mcp__electron__get_electron_window_info({ includeChildren: true });
+
+// 2. Take screenshot to see current state
+await mcp__electron__take_screenshot({ outputPath: "/tmp/current.png" });
+
+// 3. Add project to recent and trigger open
+await mcp__electron__send_command_to_electron({
+  command: "eval",
+  args: { 
+    code: `
+      const path = '/path/to/project';
+      window.electronAPI.recentProjects.add(path).then(() => {
+        window.dispatchEvent(new CustomEvent('ipc-project:open', { detail: path }));
+      });
+    `
+  }
+});
+
+// 4. Wait for project to load
+await new Promise(resolve => setTimeout(resolve, 2000));
+
+// 5. Verify project opened
+await mcp__electron__take_screenshot({ outputPath: "/tmp/after.png" });
+```
+
+## References
+
+- [Electron Remote Debugging](https://www.electronjs.org/docs/latest/tutorial/debugging-main-process)
+- [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+- [React DevTools](https://react.dev/learn/react-developer-tools)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "turbo run dev",
     "dev:desktop": "pnpm --filter @vibetree/core build && pnpm --filter @vibetree/desktop dev",
+    "dev:desktop:debug": "pnpm --filter @vibetree/core build && pnpm --filter @vibetree/desktop dev:debug",
     "dev:desktop:reset": "pnpm fix:electron && pnpm dev:desktop",
     "dev:server": "pnpm --filter @vibetree/server dev",
     "dev:web": "pnpm --filter @vibetree/web dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-reverse-portal:
+        specifier: ^2.3.0
+        version: 2.3.0(react-dom@18.3.1)(react@18.3.1)
       tailwind-merge:
         specifier: ^2.2.0
         version: 2.6.0
@@ -7897,6 +7900,16 @@ packages:
       tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@18.3.24)(react@18.3.1)
       use-sidecar: 1.1.3(@types/react@18.3.24)(react@18.3.1)
+    dev: false
+
+  /react-reverse-portal@2.3.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-kvbPfLPKg6Y3S6tVq83us2RghvDpOS4GcJxbI7cZ0V0tuzUaSzblRIhVnKLOucfqF4lN/i9oWvEmpEi6bAOYlQ==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /react-router-dom@6.30.1(react-dom@18.3.1)(react@18.3.1):


### PR DESCRIPTION
## Summary
- Each worktree now gets its own persistent TerminalGrid instance
- Terminal instances are cached and reused when switching between worktrees
- Implemented show/hide mechanism instead of recreating terminals on worktree switch

## Technical Details
This PR refactors the terminal management to preserve terminal state perfectly when switching between worktrees:

1. **Terminal Instance Caching**: Added a global cache that stores terminal instances (including xterm Terminal, fit addon, serialize addon, and DOM container) per worktree path
2. **DOM Persistence**: Terminal DOM elements are created once and moved/hidden/shown as needed
3. **React Optimization**: Used React memoization and refs to prevent unnecessary re-renders
4. **State Preservation**: Terminal scroll position, content, and running processes persist across worktree switches

## Test Plan
- [x] Build the application
- [ ] Open multiple worktrees
- [ ] Type different commands in each terminal
- [ ] Switch between worktrees and verify terminal state is preserved
- [ ] Verify scroll position is maintained
- [ ] Verify running processes continue in background terminals

🤖 Generated with [Claude Code](https://claude.ai/code)