### PR TITLE
Fix: Support worktrees with detached HEAD in app display

### DIFF
--- a/apps/desktop/src/renderer/components/WorktreePanel.tsx
+++ b/apps/desktop/src/renderer/components/WorktreePanel.tsx
@@ -176,17 +176,21 @@ export function WorktreePanel({ projectPath, selectedWorktree, onSelectWorktree,
               <button
                 onClick={() => onSelectWorktree(worktree.path)}
                 className="w-full text-left p-3 flex items-center gap-1.5"
-                data-worktree-branch={worktree.branch.replace('refs/heads/', '')}
+                data-worktree-branch={worktree.branch ? worktree.branch.replace('refs/heads/', '') : worktree.head.substring(0, 8)}
               >
                 <GitBranch className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <div className="font-medium truncate">{worktree.branch}</div>
+                  <div className="font-medium truncate">
+                    {worktree.branch 
+                      ? worktree.branch.replace('refs/heads/', '')
+                      : `Detached HEAD (${worktree.head.substring(0, 8)})`}
+                  </div>
                   <div className="text-xs text-muted-foreground truncate">
                     {worktree.path.replace('/Users/dots/Documents/projects/', '')}
                   </div>
                 </div>
               </button>
-              {worktrees.length > 1 && !worktree.branch.includes('main') && !worktree.branch.includes('master') && (
+              {worktrees.length > 1 && worktree.branch && !worktree.branch.includes('main') && !worktree.branch.includes('master') && (
                 <Button
                   size="icon"
                   variant="ghost"

--- a/apps/web/src/components/TerminalManager.tsx
+++ b/apps/web/src/components/TerminalManager.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { TerminalView } from './TerminalView';
 
 interface TerminalManagerProps {
-  worktrees: Array<{ path: string; branch: string; head: string }>;
+  worktrees: Array<{ path: string; branch?: string; head: string }>;
   selectedWorktree: string | null;
 }
 

--- a/apps/web/src/components/WorktreePanel.tsx
+++ b/apps/web/src/components/WorktreePanel.tsx
@@ -198,7 +198,9 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                   <GitBranch className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className="font-medium truncate">
-                      {worktree.branch.replace('refs/heads/', '')}
+                      {worktree.branch 
+                        ? worktree.branch.replace('refs/heads/', '')
+                        : `Detached HEAD (${worktree.head.substring(0, 8)})`}
                     </div>
                     <div className="text-xs text-muted-foreground truncate">
                       {worktree.path.split('/').slice(-2).join('/')}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,11 +19,16 @@
     "build:tsc": "tsc",
     "dev": "tsc -w",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:run": "vitest run"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",
+    "@vitest/ui": "^3.2.4",
     "esbuild": "^0.25.9",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface Worktree {
   path: string;
-  branch: string;
+  branch?: string;  // Optional - can be undefined for detached HEAD
   head: string;
 }
 

--- a/packages/core/src/utils/git-parser.test.ts
+++ b/packages/core/src/utils/git-parser.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { parseWorktrees, parseGitStatus, extractBranchName, isMainBranch } from './git-parser';
+
+describe('parseWorktrees', () => {
+  it('should parse worktrees with branches', () => {
+    const output = `worktree /Users/user/project
+HEAD abc123def456
+branch refs/heads/main
+
+worktree /Users/user/project-feature
+HEAD def456ghi789
+branch refs/heads/feature-branch
+`;
+
+    const worktrees = parseWorktrees(output);
+    
+    expect(worktrees).toHaveLength(2);
+    expect(worktrees[0]).toEqual({
+      path: '/Users/user/project',
+      head: 'abc123def456',
+      branch: 'refs/heads/main'
+    });
+    expect(worktrees[1]).toEqual({
+      path: '/Users/user/project-feature',
+      head: 'def456ghi789',
+      branch: 'refs/heads/feature-branch'
+    });
+  });
+
+  it('should parse worktrees with detached HEAD (no branch)', () => {
+    const output = `worktree /Users/user/project
+HEAD abc123def456
+branch refs/heads/main
+
+worktree /Users/user/project-detached
+HEAD 2f74501b1234567890abcdef
+`;
+
+    const worktrees = parseWorktrees(output);
+    
+    // This test currently fails because parseWorktrees filters out worktrees without a branch
+    expect(worktrees).toHaveLength(2);
+    expect(worktrees[0]).toEqual({
+      path: '/Users/user/project',
+      head: 'abc123def456',
+      branch: 'refs/heads/main'
+    });
+    expect(worktrees[1]).toEqual({
+      path: '/Users/user/project-detached',
+      head: '2f74501b1234567890abcdef',
+      branch: undefined
+    });
+  });
+
+  it('should handle mixed worktrees with some having detached HEAD', () => {
+    const output = `worktree /Users/phuongnd08/code/vibe-tree
+HEAD f5d94d31
+branch refs/heads/main
+
+worktree /Users/phuongnd08/code/vibe-tree-simplify-terminal-listener
+HEAD 2f74501b
+
+worktree /Users/phuongnd08/code/vibe-tree-use-reverse-portal
+HEAD 305c9630
+`;
+
+    const worktrees = parseWorktrees(output);
+    
+    // All three worktrees should be included, even those with detached HEAD
+    expect(worktrees).toHaveLength(3);
+    expect(worktrees[0].path).toBe('/Users/phuongnd08/code/vibe-tree');
+    expect(worktrees[0].branch).toBe('refs/heads/main');
+    expect(worktrees[1].path).toBe('/Users/phuongnd08/code/vibe-tree-simplify-terminal-listener');
+    expect(worktrees[1].branch).toBeUndefined();
+    expect(worktrees[2].path).toBe('/Users/phuongnd08/code/vibe-tree-use-reverse-portal');
+    expect(worktrees[2].branch).toBeUndefined();
+  });
+
+  it('should handle empty output', () => {
+    const worktrees = parseWorktrees('');
+    expect(worktrees).toEqual([]);
+  });
+});
+
+describe('parseGitStatus', () => {
+  it('should parse git status output correctly', () => {
+    const output = `M  src/file1.ts
+ M src/file2.ts
+?? new-file.js
+A  added-file.ts`;
+
+    const status = parseGitStatus(output);
+    
+    expect(status).toHaveLength(4);
+    expect(status[0]).toEqual({
+      path: 'src/file1.ts',
+      status: 'M ',
+      staged: true,
+      modified: false
+    });
+    expect(status[1]).toEqual({
+      path: 'src/file2.ts',
+      status: ' M',
+      staged: false,
+      modified: true
+    });
+    expect(status[2]).toEqual({
+      path: 'new-file.js',
+      status: '??',
+      staged: false,
+      modified: false
+    });
+    expect(status[3]).toEqual({
+      path: 'added-file.ts',
+      status: 'A ',
+      staged: true,
+      modified: false
+    });
+  });
+
+  it('should handle empty output', () => {
+    const status = parseGitStatus('');
+    expect(status).toEqual([]);
+  });
+});
+
+describe('extractBranchName', () => {
+  it('should extract branch name from refs format', () => {
+    expect(extractBranchName('refs/heads/main')).toBe('main');
+    expect(extractBranchName('refs/heads/feature/branch')).toBe('feature/branch');
+  });
+
+  it('should return original string if not in refs format', () => {
+    expect(extractBranchName('main')).toBe('main');
+    expect(extractBranchName('feature-branch')).toBe('feature-branch');
+  });
+});
+
+describe('isMainBranch', () => {
+  it('should identify main branches', () => {
+    expect(isMainBranch('main')).toBe(true);
+    expect(isMainBranch('master')).toBe(true);
+    expect(isMainBranch('refs/heads/main')).toBe(true);
+    expect(isMainBranch('refs/heads/master')).toBe(true);
+  });
+
+  it('should not identify feature branches as main', () => {
+    expect(isMainBranch('feature')).toBe(false);
+    expect(isMainBranch('develop')).toBe(false);
+    expect(isMainBranch('refs/heads/feature')).toBe(false);
+  });
+});

--- a/packages/core/src/utils/git-parser.ts
+++ b/packages/core/src/utils/git-parser.ts
@@ -13,7 +13,9 @@ export function parseWorktrees(output: string): Worktree[] {
   for (const line of lines) {
     if (line.startsWith('worktree ')) {
       // If we have a complete worktree, add it to the array
-      if (current.path && current.branch && current.head) {
+      // A worktree is complete if it has at least a path and head
+      // Branch is optional (can be undefined for detached HEAD)
+      if (current.path && current.head) {
         worktrees.push(current as Worktree);
       }
       // Start a new worktree entry
@@ -26,7 +28,9 @@ export function parseWorktrees(output: string): Worktree[] {
   }
 
   // Add the last worktree if complete
-  if (current.path && current.branch && current.head) {
+  // A worktree is complete if it has at least a path and head
+  // Branch is optional (can be undefined for detached HEAD)
+  if (current.path && current.head) {
     worktrees.push(current as Worktree);
   }
 

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,12 +320,18 @@ importers:
       '@types/node':
         specifier: ^20.11.5
         version: 20.19.11
+      '@vitest/ui':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       esbuild:
         specifier: ^0.25.9
         version: 0.25.9
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.11)(@vitest/ui@3.2.4)
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixed issue where worktrees in detached HEAD state were not displayed in the app
- Made the branch property optional in the Worktree interface to support detached HEAD
- Updated UI components to gracefully handle missing branch information

## Problem
The app wasn't showing worktrees that were in detached HEAD state (e.g., when checking out a specific commit). The `git worktree list` command output for such worktrees doesn't include a branch field, which caused them to be filtered out by the parsing logic.

## Solution
- Modified `parseWorktrees` function to include worktrees without branches
- Updated the Worktree TypeScript interface to make branch optional
- Enhanced UI components to display "Detached HEAD (commit-hash)" for such worktrees
- Added comprehensive unit tests to verify the fix

## Test Plan
- [x] Added unit tests for parseWorktrees function covering:
  - Normal worktrees with branches
  - Worktrees with detached HEAD
  - Mixed scenarios
- [x] Verified all existing tests pass
- [x] TypeScript compilation succeeds without errors
- [x] Manually tested with actual git worktrees in detached HEAD state

🤖 Generated with [Claude Code](https://claude.ai/code)